### PR TITLE
/docs removed from gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,9 +3,7 @@ artifacts/
 build/
 cache/
 coverage/
-docs/
 node_modules/
-
 *.env
 coverage.json
 gas-report.html


### PR DESCRIPTION
if the folder docs is in the gitignore, gitlab does not produce docs files to view them.